### PR TITLE
chore: use python 3.10 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: Prepare build env
         run: python -m pip install build mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ include_package_data = True
 python_requires = >=3.5
 install_requires =
     aiohttp
-    pyjwt[crypto]
+    pyjwt[crypto] >=2.1.0
     pytz
 
 [options.package_data]


### PR DESCRIPTION
<img width="682" alt="image" src="https://user-images.githubusercontent.com/577219/155898189-63406cac-4a9e-47a1-9f96-4a43a31e2a88.png">

https://discord.com/channels/934223496245018644/934223544454377502/947394949916270642

Looks like HA 2022.3.x is going to start using python 3.10. Dependency resolution seems to have changed and our deps don't work out of the box. Let's get CI using this version to first see if we can repro and if so to validate going forward that our builds work.