### PR TITLE
fix: pyjwt[crypto] >=2.2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.10'
+          python-version: '3.9'
 
       - name: Prepare build env
         run: python -m pip install build mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2", "pip>=21.0,<22.1"]
+requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2", "pip>=21.0,<22.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ include_package_data = True
 python_requires = >=3.9
 install_requires =
     aiohttp
-    pyjwt[crypto] = >=2.2.0
+    pyjwt[crypto] >=2.2.0
     pytz
 
 [options.package_data]

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,10 +19,10 @@ classifiers =
 packages =
     toyota_na
 include_package_data = True
-python_requires = >=3.5
+python_requires = >=3.9
 install_requires =
     aiohttp
-    pyjwt[crypto] >=2.1.0
+    pyjwt[crypto]==2.1.0
     pytz
 
 [options.package_data]

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ include_package_data = True
 python_requires = >=3.9
 install_requires =
     aiohttp
-    pyjwt[crypto]==2.1.0
+    pyjwt[crypto]= >=2.2.0
     pytz
 
 [options.package_data]

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ include_package_data = True
 python_requires = >=3.9
 install_requires =
     aiohttp
-    pyjwt[crypto]= >=2.2.0
+    pyjwt[crypto] = >=2.2.0
     pytz
 
 [options.package_data]


### PR DESCRIPTION
This bump should fix an issue we've been having with the latest version of Home Assistant (2022.03.x)

- Properly fixes #14 