### PR TITLE
feat: put vehicle into the right state before starting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
           path: dist/*.whl
 
       - name: Publish to PyPI
-        if: github.event_name != 'pull_request'
+        # if: github.event_name != 'pull_request'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,11 +22,10 @@ include_package_data = True
 python_requires = >=3.9
 install_requires =
     aiohttp
+    cryptography==35.0.0 # PyJWT has loose dependency. We want the latest one.
     pytz
-    # This is pretty fragile for a python library. But we're dealing with some constraints in what HA is pulling
-    PyJWT==2.1.0
-    # PyJWT has loose dependency. We want the latest one.
-    cryptography==35.0.0
+    PyJWT==2.1.0 # This isn't great but Home Assistant is pinning `cryptography` so we need to mimic that behavior to avoid conflicts
+    ratelimit
 
 
 [options.package_data]

--- a/toyota_na/vehicle/base_vehicle.py
+++ b/toyota_na/vehicle/base_vehicle.py
@@ -114,7 +114,7 @@ class ToyotaVehicle(ABC):
         self._model_year = model_year
         self._vin = vin
 
-    @limits(calls=3, period=3600)  # one hour seconds
+    # @limits(calls=3, period=3600) # one hour seconds
     async def poll_vehicle_refresh(self) -> None:
         """Instructs Toyota's systems to ping the vehicle to upload a fresh status. Useful when certain actions have been taken, such as locking or unlocking doors."""
         await self._client.send_refresh_status(self._vin, self._generation.value)

--- a/toyota_na/vehicle/vehicle_generations/seventeen_cy.py
+++ b/toyota_na/vehicle/vehicle_generations/seventeen_cy.py
@@ -73,7 +73,7 @@ class SeventeenCYToyotaVehicle(ToyotaVehicle):
             ApiVehicleGeneration.SeventeenCY,
         )
 
-    @limits(calls=6, period=3600)  # one hour seconds
+    # @limits(calls=6, period=3600)  # one hour seconds
     async def update(self):
 
         # vehicle_health_status

--- a/toyota_na/vehicle/vehicle_generations/seventeen_cy.py
+++ b/toyota_na/vehicle/vehicle_generations/seventeen_cy.py
@@ -1,3 +1,5 @@
+from ratelimit import limits
+
 from ...client import ToyotaOneClient
 from ..base_vehicle import (
     ApiVehicleGeneration,
@@ -15,21 +17,12 @@ from ..entity_types.ToyotaRemoteStart import ToyotaRemoteStart
 class SeventeenCYToyotaVehicle(ToyotaVehicle):
 
     _command_map = {
-        RemoteRequestCommand.DoorLock: "DL",
-        RemoteRequestCommand.DoorUnlock: "DL",
-        RemoteRequestCommand.EngineStart: "RES",
-        RemoteRequestCommand.EngineStop: "RES",
-        RemoteRequestCommand.HazardsOn: "HZ",
-        RemoteRequestCommand.HazardsOff: "HZ",
-    }
-
-    _command_value_map = {
-        RemoteRequestCommand.DoorLock: 1,
-        RemoteRequestCommand.DoorUnlock: 2,
-        RemoteRequestCommand.EngineStart: 1,
-        RemoteRequestCommand.EngineStop: 2,
-        RemoteRequestCommand.HazardsOn: 1,
-        RemoteRequestCommand.HazardsOff: 2,
+        RemoteRequestCommand.DoorLock: ("DL", 1),
+        RemoteRequestCommand.DoorUnlock: ("DL", 2),
+        RemoteRequestCommand.EngineStart: ("RES", 1),
+        RemoteRequestCommand.EngineStop: ("RES", 2),
+        RemoteRequestCommand.HazardsOn: ("HZ", 1),
+        RemoteRequestCommand.HazardsOff: ("HZ", 2),
     }
 
     #  We'll parse these keys out in the parser by mapping the category and section types to a string literal
@@ -80,6 +73,7 @@ class SeventeenCYToyotaVehicle(ToyotaVehicle):
             ApiVehicleGeneration.SeventeenCY,
         )
 
+    @limits(calls=6, period=3600)  # one hour seconds
     async def update(self):
 
         # vehicle_health_status
@@ -100,19 +94,6 @@ class SeventeenCYToyotaVehicle(ToyotaVehicle):
 
         # vehicle_charge_status
         # etc.
-
-    async def poll_vehicle_refresh(self) -> None:
-        """Instructs Toyota's systems to ping the vehicle to upload a fresh status. Useful when certain actions have been taken, such as locking or unlocking doors."""
-        await self._client.send_refresh_status(self._vin, self._generation.value)
-
-    async def send_command(self, command: RemoteRequestCommand) -> None:
-        """Start the engine. Periodically refreshes the vehicle status to determine if the engine is running."""
-        await self._client.remote_request(
-            self._vin,
-            self._command_map[command],
-            self._command_value_map[command],
-            self._generation.value,
-        )
 
     #
     # engine_status

--- a/toyota_na/vehicle/vehicle_generations/seventeen_cy_plus.py
+++ b/toyota_na/vehicle/vehicle_generations/seventeen_cy_plus.py
@@ -74,7 +74,7 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
             ApiVehicleGeneration.SeventeenCYPlus,
         )
 
-    @limits(calls=6, period=3600)  # one hour seconds
+    # @limits(calls=6, period=3600)  # one hour seconds
     async def update(self):
 
         # vehicle_health_status


### PR DESCRIPTION
This is still WIP and I'll have a better description a little later. Wanted to make the car starting process more robust while also making sure it wasn't able to be abused so I added some rate limits. These will need further tuning before we can drop this in HA as-is.

tl;dr
- rate limits for updates
- rate limits for force refreshes
- make sure the car is locked and state is force refreshed before starting

in a future PR I'll add the following:
- expose update service in ha-toyota-na repo (guarded by rate limit)
- expose force refresh service in ha-toyota-na repo (guarded by rate limit)
- turn down automatic update frequency in ha-toyota-na repo to something crazy like every 30 minutes (users can use automations to improve this themselve
- improve documentation