### PR TITLE
fix: stop pinning pyjwt and crypto deps

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,12 +22,9 @@ include_package_data = True
 python_requires = >=3.9
 install_requires =
     aiohttp
+    cryptography>=35.0.0 # PyJWT has loose dependency. We want the latest one.
     pytz
-    # This is pretty fragile for a python library. But we're dealing with some constraints in what HA is pulling
-    PyJWT==2.1.0
-    # PyJWT has loose dependency. We want the latest one.
-    cryptography==35.0.0
-
+    PyJWT>=2.1.0 # This isn't great but Home Assistant is pinning `cryptography` so we need to mimic that behavior to avoid conflicts
 
 [options.package_data]
 * = *.pyi


### PR DESCRIPTION
HA bumped pyjwt again and we were statically pinning the dep. I've loosened the restriction. Will merge shortly to get a test build out I can play with.