### PR TITLE
Skip attempt to add vehicle if not one of matching generations

### DIFF
--- a/toyota_na/vehicle/vehicle.py
+++ b/toyota_na/vehicle/vehicle.py
@@ -33,6 +33,8 @@ async def get_vehicles(client: ToyotaOneClient) -> list[ToyotaVehicle]:
                 model_year=vehicle["modelYear"],
                 vin=vehicle["vin"],
             )
+        else:
+            continue
 
         await vehicle.update()
         vehicles.append(vehicle)


### PR DESCRIPTION
When you get a non-matching generation back because of variable scope, we attempt to call an update an the RAW vehicle object. This will just skip pass any that don't match explicit supported vehicle generations.