### PR TITLE
feat: publish a release build when pushing a release on github

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ on:
     branches:
       - master
 
+  release:
+    types: [published]
+
 jobs:
   build_wheels:
     name: Build wheels on ubuntu-latest


### PR DESCRIPTION
After merging a PR to `master` there's no way to trigger CI to do another build with a real release number. This copies the trigger we use on the HA side so we'll run another CI flow when release notes are published to trigger a release build to pypi.