### PR TITLE
fix: Error 500 on setup and Safety Connect Support

### DIFF
--- a/toyota_na/vehicle/base_vehicle.py
+++ b/toyota_na/vehicle/base_vehicle.py
@@ -79,7 +79,7 @@ class ToyotaVehicle(ABC):
             ToyotaOpening,
         ],
     ]
-    _has_remote_subscription = False
+    _subscriptions = []
     _model_name: str
     _model_year: str
     _generation: ApiVehicleGeneration
@@ -88,7 +88,7 @@ class ToyotaVehicle(ABC):
     def __init__(
         self,
         client: ToyotaOneClient,
-        has_remote_subscription,
+        subscriptions: list[str],
         model_name: str,
         model_year: str,
         vin: str,
@@ -103,7 +103,7 @@ class ToyotaVehicle(ABC):
         self._features = {}
         self._client = client
         self._generation = generation
-        self._has_remote_subscription = has_remote_subscription
+        self._subscriptions = subscriptions
         self._model_name = model_name
         self._model_year = model_year
         self._vin = vin
@@ -154,7 +154,15 @@ class ToyotaVehicle(ABC):
 
     @property
     def subscribed(self):
-        return self._has_remote_subscription
+        return self.remote_subscribed or self.health_subscribed
+
+    @property
+    def remote_subscribed(self):
+        return "Remote Connect" in self._subscriptions
+
+    @property
+    def health_subscribed(self):
+        return "Safety Connect" in self._subscriptions
 
     @property
     def vin(self):

--- a/toyota_na/vehicle/vehicle.py
+++ b/toyota_na/vehicle/vehicle.py
@@ -18,7 +18,7 @@ async def get_vehicles(client: ToyotaOneClient) -> list[ToyotaVehicle]:
         ):
             vehicle = SeventeenCYPlusToyotaVehicle(
                 client=client,
-                has_remote_subscription=vehicle["remoteSubscriptionStatus"] == "ACTIVE",
+                subscriptions=await get_subscriptions(vehicle),
                 model_name=vehicle["modelName"],
                 model_year=vehicle["modelYear"],
                 vin=vehicle["vin"],
@@ -27,7 +27,7 @@ async def get_vehicles(client: ToyotaOneClient) -> list[ToyotaVehicle]:
         elif ApiVehicleGeneration(vehicle["generation"]) == ApiVehicleGeneration.CY17:
             vehicle = SeventeenCYToyotaVehicle(
                 client=client,
-                has_remote_subscription=vehicle["remoteSubscriptionStatus"] == "ACTIVE",
+                subscriptions=await get_subscriptions(vehicle),
                 model_name=vehicle["modelName"],
                 model_year=vehicle["modelYear"],
                 vin=vehicle["vin"],
@@ -37,3 +37,11 @@ async def get_vehicles(client: ToyotaOneClient) -> list[ToyotaVehicle]:
         vehicles.append(vehicle)
 
     return vehicles
+
+
+async def get_subscriptions(vehicle: dict) -> list[str]:
+    subscriptions = []
+    for sub in vehicle["subscriptions"]:
+        if sub["status"] in ["ACTIVE", "WAIVED"]:
+            subscriptions.append(sub["productName"])
+    return subscriptions

--- a/toyota_na/vehicle/vehicle_generations/seventeen_cy.py
+++ b/toyota_na/vehicle/vehicle_generations/seventeen_cy.py
@@ -82,21 +82,21 @@ class SeventeenCYToyotaVehicle(ToyotaVehicle):
 
     async def update(self):
 
-        # vehicle_health_status
-        vehicle_status = await self._client.get_vehicle_status(
-            self._vin, self._generation.value
-        )
-        self._parse_vehicle_status(vehicle_status)
-
         # telemetry
         telemetry = await self._client.get_telemetry(self._vin, self._generation.value)
         self._parse_telemetry(telemetry)
+        if self.subscribed:
+            # vehicle_health_status
+            vehicle_status = await self._client.get_vehicle_status(
+                self._vin, self._generation.value
+                )
+            self._parse_vehicle_status(vehicle_status)
 
-        # engine_status
-        engine_status = await self._client.get_engine_status(
+            # engine_status
+            engine_status = await self._client.get_engine_status(
             self._vin, self._generation.value
-        )
-        self._parse_engine_status(engine_status)
+            )
+            self._parse_engine_status(engine_status)
 
         # vehicle_charge_status
         # etc.

--- a/toyota_na/vehicle/vehicle_generations/seventeen_cy.py
+++ b/toyota_na/vehicle/vehicle_generations/seventeen_cy.py
@@ -65,7 +65,7 @@ class SeventeenCYToyotaVehicle(ToyotaVehicle):
     def __init__(
         self,
         client: ToyotaOneClient,
-        has_remote_subscription: bool,
+        subscriptions: list,
         model_name: str,
         model_year: str,
         vin: str,
@@ -73,7 +73,7 @@ class SeventeenCYToyotaVehicle(ToyotaVehicle):
         ToyotaVehicle.__init__(
             self,
             client,
-            has_remote_subscription,
+            subscriptions,
             model_name,
             model_year,
             vin,
@@ -85,7 +85,7 @@ class SeventeenCYToyotaVehicle(ToyotaVehicle):
         # telemetry
         telemetry = await self._client.get_telemetry(self._vin, self._generation.value)
         self._parse_telemetry(telemetry)
-        if self.subscribed:
+        if self.remote_subscribed:
             # vehicle_health_status
             vehicle_status = await self._client.get_vehicle_status(
                 self._vin, self._generation.value

--- a/toyota_na/vehicle/vehicle_generations/seventeen_cy_plus.py
+++ b/toyota_na/vehicle/vehicle_generations/seventeen_cy_plus.py
@@ -73,17 +73,22 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
 
     async def update(self):
 
-        # vehicle_health_status
-        vehicle_status = await self._client.get_vehicle_status(self._vin)
-        self._parse_vehicle_status(vehicle_status)
-
         # telemetry
         telemetry = await self._client.get_telemetry(self._vin)
         self._parse_telemetry(telemetry)
+        if self.subscribed:
+            # vehicle_health_status
+            vehicle_status = await self._client.get_vehicle_status(self._vin)
+            self._parse_vehicle_status(vehicle_status)
 
-        # engine_status
-        engine_status = await self._client.get_engine_status(self._vin)
-        self._parse_engine_status(engine_status)
+            # engine_status
+            engine_status = await self._client.get_engine_status(self._vin)
+            self._parse_engine_status(engine_status)
+        else:
+            pass
+
+
+
 
         # vehicle_charge_status
         # etc.

--- a/toyota_na/vehicle/vehicle_generations/seventeen_cy_plus.py
+++ b/toyota_na/vehicle/vehicle_generations/seventeen_cy_plus.py
@@ -56,7 +56,7 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
     def __init__(
         self,
         client: ToyotaOneClient,
-        has_remote_subscription: bool,
+        subscriptions: list,
         model_name: str,
         model_year: str,
         vin: str,
@@ -64,7 +64,7 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
         ToyotaVehicle.__init__(
             self,
             client,
-            has_remote_subscription,
+            subscriptions,
             model_name,
             model_year,
             vin,
@@ -76,7 +76,7 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
         # telemetry
         telemetry = await self._client.get_telemetry(self._vin)
         self._parse_telemetry(telemetry)
-        if self.subscribed:
+        if self.remote_subscribed:
             # vehicle_health_status
             vehicle_status = await self._client.get_vehicle_status(self._vin)
             self._parse_vehicle_status(vehicle_status)


### PR DESCRIPTION
Currently both get_vehicle_status and get_engine_status require a remote connect subscription to function. Attempting to use either of these will throw a ClientResponseError that causes HA to fail to setup the integration. This also adds support for vehicles that only have safety connect.